### PR TITLE
EnableDLCWeaponsOnMapChange

### DIFF
--- a/MadnessPatch/MadnessPatch.ini
+++ b/MadnessPatch/MadnessPatch.ini
@@ -53,6 +53,11 @@ MaxProcessorCount = 2
 ; 0 = Disabled, 1 = Enabled
 UnlockCompleteEditionDLC = 1
 
+; Alternative fix that re-enables the DLC weapons after every map change so they
+; stay usable throughout the game (requires UnlockCompleteEditionDLC)
+; 0 = Disabled, 1 = Enabled
+EnableDLCWeaponsOnMapChange = 0
+
 ; Disables deprecated Unreal Engine 3 driver compatibility hacks designed for legacy GPUs
 ; May improve performance on modern hardware
 ; 0 = Disabled, 1 = Enabled

--- a/MadnessPatch/MadnessPatch.vcxproj
+++ b/MadnessPatch/MadnessPatch.vcxproj
@@ -111,6 +111,7 @@
     <ClCompile Include="..\include\SDK\SDK_HEADERS\WinDrv_classes.cpp" />
     <ClCompile Include="..\include\SDK\SDK_HEADERS\XAudio2_classes.cpp" />
     <ClCompile Include="..\src\dllmain.cpp" />
+    <ClCompile Include="..\src\EnableDLCWeaponsOnMapChange.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="MadnessPatch.ini">
@@ -121,6 +122,7 @@
   <ItemGroup>
     <ClInclude Include="..\include\Controller.hpp" />
     <ClInclude Include="..\include\CrashHandler.hpp" />
+    <ClInclude Include="..\include\EnableDLCWeaponsOnMapChange.hpp" />
     <ClInclude Include="..\include\FixIniBindings.hpp" />
     <ClInclude Include="..\include\ini.hpp" />
     <ClInclude Include="..\include\MFortress\Patches_EA.hpp" />

--- a/README.md
+++ b/README.md
@@ -178,6 +178,8 @@ Set `MaxFPS` in `MadnessPatch.ini` (0 = disable, recommended maximum: 120).
 Unlocks all Complete Edition costumes, weapons, and adds a menu option to launch the original Alice game without editing the game's files.
 > **Note**: While weapons are showing up, they are not functional. See: [AESylum](https://github.com/Wemino/AESylum)
 
+As an alternative, the optional `EnableDLCWeaponsOnMapChange` setting (disabled by default) re-enables the DLC weapons after every map change so they stay usable throughout the game.
+
 ## Improved Window Management
 
 Fixes window management to allow standard Windows functionality:

--- a/include/EnableDLCWeaponsOnMapChange.hpp
+++ b/include/EnableDLCWeaponsOnMapChange.hpp
@@ -6,5 +6,5 @@
 namespace EnableDLCWeaponsFix
 {
 	void Install(HMODULE gameModule, uintptr_t playerControllerSlot);
-	void Stop();
+	void Tick();
 }

--- a/include/EnableDLCWeaponsOnMapChange.hpp
+++ b/include/EnableDLCWeaponsOnMapChange.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstdint>
+#include <windows.h>
+
+namespace EnableDLCWeaponsFix
+{
+	void Install(HMODULE gameModule, uintptr_t playerControllerSlot);
+	void Stop();
+}

--- a/src/EnableDLCWeaponsOnMapChange.cpp
+++ b/src/EnableDLCWeaponsOnMapChange.cpp
@@ -1,0 +1,166 @@
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+
+#include <windows.h>
+#include <atomic>
+#include <thread>
+#include <cstring>
+
+#include "EnableDLCWeaponsOnMapChange.hpp"
+#include "SDK/SdkHeaders.hpp"
+
+namespace EnableDLCWeaponsFix
+{
+	namespace
+	{
+		std::atomic<bool> g_running{ false };
+		std::atomic<bool> g_stop{ false };
+
+		bool IsReadable(const void* ptr, size_t size)
+		{
+			MEMORY_BASIC_INFORMATION mbi;
+			if (!ptr || !VirtualQuery(ptr, &mbi, sizeof(mbi)))
+				return false;
+
+			if (mbi.State != MEM_COMMIT || (mbi.Protect & PAGE_GUARD))
+				return false;
+
+			if (!(mbi.Protect & (PAGE_READONLY | PAGE_READWRITE | PAGE_EXECUTE_READ | PAGE_EXECUTE_READWRITE)))
+				return false;
+
+			return (reinterpret_cast<uintptr_t>(ptr) + size) <= (reinterpret_cast<uintptr_t>(mbi.BaseAddress) + mbi.RegionSize);
+		}
+
+		UFunction* FindFunction(UObject* Object, const char* FunctionName)
+		{
+			if (!IsReadable(Object, 0x38))
+				return nullptr;
+
+			int depth = 0;
+			for (UStruct* Class = Object->Class; IsReadable(Class, 0x50) && depth < 32; Class = Class->SuperField, ++depth)
+			{
+				int guard = 0;
+				for (UField* Field = Class->Children; IsReadable(Field, 0x44) && guard < 100000; Field = Field->Next, ++guard)
+				{
+					FNameEntry* Entry = Field->Name.GetEntry();
+
+					if (IsReadable(Entry, 0x18) && strcmp(Entry->Name, FunctionName) == 0)
+					{
+						return reinterpret_cast<UFunction*>(Field);
+					}
+				}
+			}
+
+			return nullptr;
+		}
+
+		APlayerController* ReadController(uintptr_t slot)
+		{
+			__try
+			{
+				if (!IsReadable(reinterpret_cast<void*>(slot), sizeof(void*)))
+					return nullptr;
+
+				APlayerController* controller = *reinterpret_cast<APlayerController**>(slot);
+				if (!IsReadable(controller, 0x230) || !controller->Pawn)
+					return nullptr;
+
+				return controller;
+			}
+			__except (EXCEPTION_EXECUTE_HANDLER)
+			{
+				return nullptr;
+			}
+		}
+
+		bool EnableDLCWeapons(APlayerController* Controller, UFunction*& Function)
+		{
+			__try
+			{
+				if (!Function)
+				{
+					Function = FindFunction(Controller, "EnableAllDLCWeapons");
+				}
+
+				if (!Function)
+				{
+					return false;
+				}
+
+				unsigned char params[8] = { 0 };
+				Controller->ProcessEvent(Function, params, nullptr);
+				return true;
+			}
+			__except (EXCEPTION_EXECUTE_HANDLER)
+			{
+				return false;
+			}
+		}
+
+		void Watch(uintptr_t controllerSlot)
+		{
+			UFunction* enableFunction = nullptr;
+			APlayerController* lastController = nullptr;
+			bool pending = false;
+			int ticks = 0;
+
+			while (!g_stop.load(std::memory_order_relaxed))
+			{
+				Sleep(250);
+
+				APlayerController* controller = ReadController(controllerSlot);
+				if (!controller)
+				{
+					continue;
+				}
+
+				if (controller != lastController)
+				{
+					lastController = controller;
+					pending = true;
+					ticks = 0;
+				}
+
+				if (!pending)
+				{
+					continue;
+				}
+
+				++ticks;
+
+				if (ticks == 2 || ticks == 20 || ticks == 40)
+				{
+					EnableDLCWeapons(controller, enableFunction);
+				}
+
+				if (ticks >= 40)
+				{
+					pending = false;
+				}
+			}
+
+			g_running.store(false, std::memory_order_relaxed);
+		}
+	}
+
+	void Install(HMODULE gameModule, uintptr_t playerControllerSlot)
+	{
+		if (!gameModule || !playerControllerSlot || g_running.exchange(true))
+		{
+			return;
+		}
+
+		GNames = reinterpret_cast<TArray<FNameEntry*>*>(reinterpret_cast<uintptr_t>(gameModule) + static_cast<uintptr_t>(GNames_Offset));
+
+		HMODULE pinned = nullptr;
+		GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN, reinterpret_cast<LPCWSTR>(&Watch), &pinned);
+
+		g_stop.store(false, std::memory_order_relaxed);
+		std::thread(Watch, playerControllerSlot).detach();
+	}
+
+	void Stop()
+	{
+		g_stop.store(true, std::memory_order_relaxed);
+	}
+}

--- a/src/EnableDLCWeaponsOnMapChange.cpp
+++ b/src/EnableDLCWeaponsOnMapChange.cpp
@@ -2,8 +2,6 @@
 #define WIN32_LEAN_AND_MEAN
 
 #include <windows.h>
-#include <atomic>
-#include <thread>
 #include <cstring>
 
 #include "EnableDLCWeaponsOnMapChange.hpp"
@@ -13,8 +11,11 @@ namespace EnableDLCWeaponsFix
 {
 	namespace
 	{
-		std::atomic<bool> g_running{ false };
-		std::atomic<bool> g_stop{ false };
+		uintptr_t g_controllerSlot = 0;
+		APlayerController* g_lastController = nullptr;
+		UFunction* g_enableFunction = nullptr;
+		DWORD g_changeTime = 0;
+		int g_fireStage = 0;
 
 		bool IsReadable(const void* ptr, size_t size)
 		{
@@ -73,94 +74,68 @@ namespace EnableDLCWeaponsFix
 			}
 		}
 
-		bool EnableDLCWeapons(APlayerController* Controller, UFunction*& Function)
+		void EnableDLCWeapons(APlayerController* Controller)
 		{
 			__try
 			{
-				if (!Function)
+				if (!g_enableFunction)
 				{
-					Function = FindFunction(Controller, "EnableAllDLCWeapons");
+					g_enableFunction = FindFunction(Controller, "EnableAllDLCWeapons");
 				}
 
-				if (!Function)
+				if (g_enableFunction)
 				{
-					return false;
+					unsigned char params[8] = { 0 };
+					Controller->ProcessEvent(g_enableFunction, params, nullptr);
 				}
-
-				unsigned char params[8] = { 0 };
-				Controller->ProcessEvent(Function, params, nullptr);
-				return true;
 			}
 			__except (EXCEPTION_EXECUTE_HANDLER)
 			{
-				return false;
 			}
-		}
-
-		void Watch(uintptr_t controllerSlot)
-		{
-			UFunction* enableFunction = nullptr;
-			APlayerController* lastController = nullptr;
-			bool pending = false;
-			int ticks = 0;
-
-			while (!g_stop.load(std::memory_order_relaxed))
-			{
-				Sleep(250);
-
-				APlayerController* controller = ReadController(controllerSlot);
-				if (!controller)
-				{
-					continue;
-				}
-
-				if (controller != lastController)
-				{
-					lastController = controller;
-					pending = true;
-					ticks = 0;
-				}
-
-				if (!pending)
-				{
-					continue;
-				}
-
-				++ticks;
-
-				if (ticks == 2 || ticks == 20 || ticks == 40)
-				{
-					EnableDLCWeapons(controller, enableFunction);
-				}
-
-				if (ticks >= 40)
-				{
-					pending = false;
-				}
-			}
-
-			g_running.store(false, std::memory_order_relaxed);
 		}
 	}
 
 	void Install(HMODULE gameModule, uintptr_t playerControllerSlot)
 	{
-		if (!gameModule || !playerControllerSlot || g_running.exchange(true))
-		{
+		if (!gameModule || !playerControllerSlot)
 			return;
-		}
 
 		GNames = reinterpret_cast<TArray<FNameEntry*>*>(reinterpret_cast<uintptr_t>(gameModule) + static_cast<uintptr_t>(GNames_Offset));
-
-		HMODULE pinned = nullptr;
-		GetModuleHandleExW(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_PIN, reinterpret_cast<LPCWSTR>(&Watch), &pinned);
-
-		g_stop.store(false, std::memory_order_relaxed);
-		std::thread(Watch, playerControllerSlot).detach();
+		g_controllerSlot = playerControllerSlot;
 	}
 
-	void Stop()
+	void Tick()
 	{
-		g_stop.store(true, std::memory_order_relaxed);
+		if (!g_controllerSlot)
+			return;
+
+		APlayerController* controller = ReadController(g_controllerSlot);
+		if (!controller)
+			return;
+
+		if (controller != g_lastController)
+		{
+			g_lastController = controller;
+			g_changeTime = GetTickCount();
+			g_fireStage = 0;
+		}
+
+		const DWORD elapsed = GetTickCount() - g_changeTime;
+
+		if (g_fireStage == 0 && elapsed >= 500)
+		{
+			EnableDLCWeapons(controller);
+			g_fireStage = 1;
+		}
+		else if (g_fireStage == 1 && elapsed >= 5000)
+		{
+			EnableDLCWeapons(controller);
+			g_fireStage = 2;
+		}
+		else if (g_fireStage == 2 && elapsed >= 10000)
+		{
+			EnableDLCWeapons(controller);
+			g_fireStage = 3;
+		}
 	}
 }

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -16,6 +16,7 @@
 #include "helper.hpp"
 #include "FixIniBindings.hpp"
 #include "CrashHandler.hpp"
+#include "EnableDLCWeaponsOnMapChange.hpp"
 
 #pragma comment(lib, "shlwapi.lib")
 #pragma comment(lib, "SDL3-static.lib")
@@ -144,6 +145,7 @@ int MaxProcessorCount = 0;
 
 // General
 bool UnlockCompleteEditionDLC = false;
+bool EnableDLCWeaponsOnMapChange = false;
 bool DisableLegacyDriverHacks = false;
 bool CheckAlice1InstallFolder = false;
 bool SkipEAIntro = false;
@@ -247,6 +249,7 @@ static void ReadConfig()
 	
 	// General
 	UnlockCompleteEditionDLC = IniHelper::ReadInteger("General", "UnlockCompleteEditionDLC", 1) == 1;
+	EnableDLCWeaponsOnMapChange = IniHelper::ReadInteger("General", "EnableDLCWeaponsOnMapChange", 0) == 1;
 	DisableLegacyDriverHacks = IniHelper::ReadInteger("General", "DisableLegacyDriverHacks", 1) == 1;
 	CheckAlice1InstallFolder = IniHelper::ReadInteger("General", "CheckAlice1InstallFolder", 1) == 1;
 	SkipEAIntro = IniHelper::ReadInteger("General", "SkipEAIntro", 0) == 1;
@@ -1599,6 +1602,13 @@ static void ApplyCheckAlice1InstallFolder()
 	);
 }
 
+static void ApplyEnableDLCWeaponsOnMapChange()
+{
+	if (!EnableDLCWeaponsOnMapChange) return;
+
+	EnableDLCWeaponsFix::Install(g_State.GameModule, reinterpret_cast<uintptr_t>(&g_State.pInput));
+}
+
 static void ApplyFontScaling()
 {
 	if (!FontScaling) return;
@@ -1906,7 +1916,7 @@ static void ApplyResolutionHook()
 
 static void ApplyGetPointerHook()
 {
-	if (!DisableMouseAcceleration && !FixUltraWideScreenFOV && !DisableBackgroundLevelStreaming) return;
+	if (!DisableMouseAcceleration && !FixUltraWideScreenFOV && !DisableBackgroundLevelStreaming && !EnableDLCWeaponsOnMapChange) return;
 
 	DWORD addr_PlayActorPtr = ScanModuleSignature(g_State.GameModule, "89 47 40 8B 45 ?? 88 5D FC 89 5D ?? 89 5D ?? 3B C3 74 0E 6A 01 50 E8 ?? ?? ?? ?? 83 C4 08 89 5D", "PlayActorPtr");
 	DWORD addr_UpdatePlayActorPtr = ScanModuleSignature(g_State.GameModule, "2C 02 00 00 ?? ?? 14 06 00 00", "UpdatePlayActorPtr");
@@ -1985,6 +1995,7 @@ static void Init()
 	ApplyIniSettingsHook();
 	ApplyIntroSkip();
 	ApplyCheckAlice1InstallFolder();
+	ApplyEnableDLCWeaponsOnMapChange();
 
 	// Display
 	ApplyFontScaling();
@@ -2082,6 +2093,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 		}
 		case DLL_PROCESS_DETACH:
 		{
+			EnableDLCWeaponsFix::Stop();
 			break;
 		}
 	}

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -658,6 +658,11 @@ static SafetyHookInline GetMaxTickRate{};
 
 static double __fastcall GetMaxTickRate_Hook(int thisp, int, float a2, int a3)
 {
+	if (EnableDLCWeaponsOnMapChange)
+	{
+		EnableDLCWeaponsFix::Tick();
+	}
+
 	if (g_State.set40fps != g_State.prev_set40fps)
 	{
 		if (g_State.set40fps)
@@ -1607,6 +1612,18 @@ static void ApplyEnableDLCWeaponsOnMapChange()
 	if (!EnableDLCWeaponsOnMapChange) return;
 
 	EnableDLCWeaponsFix::Install(g_State.GameModule, reinterpret_cast<uintptr_t>(&g_State.pInput));
+
+	// The DLC weapons must be re-enabled from the game thread, so drive it from
+	// the per-frame GetMaxTickRate hook (shared with FixHashTableRaceCondition).
+	if (!GetMaxTickRate)
+	{
+		DWORD addr_GetMaxTickRate = ScanModuleSignature(g_State.GameModule, "55 8B EC 6A FF 68 ?? ?? ?? ?? 64 A1 00 00 00 00 50 83 EC 14 56 A1 ?? ?? ?? ?? 33 C5 50 8D 45 F4 64 A3 00 00 00 00 8B F1 C7 45 EC 00 00 00 00 F7", "DLCWeapons_GetMaxTickRate");
+
+		if (addr_GetMaxTickRate != 0)
+		{
+			GetMaxTickRate = HookHelper::CreateHook((void*)addr_GetMaxTickRate, &GetMaxTickRate_Hook);
+		}
+	}
 }
 
 static void ApplyFontScaling()
@@ -2093,7 +2110,6 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserv
 		}
 		case DLL_PROCESS_DETACH:
 		{
-			EnableDLCWeaponsFix::Stop();
 			break;
 		}
 	}


### PR DESCRIPTION
As an alternative to downgrading the game this re-enables the DLC weapons by calling the "EnableAllDLCWeapons" function after every map change.

Also related to https://github.com/Wemino/MadnessPatch/issues/9